### PR TITLE
Restructure docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,10 +62,12 @@
     "scripts": {
         "check": [
             "@cs",
-            "@test"
+            "@test",
+            "@docheader"
         ],
         "cs": "php-cs-fixer fix -v --diff --dry-run",
         "cs-fix": "php-cs-fixer fix -v --diff",
+        "docheader": "docheader check src/ tests/",
         "test": "phpunit"
     }
 }

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,9 +1,11 @@
 {
-  "title": "Prooph Memcached SnapshotStore",
+  "title": "Memcached Snapshot Store",
   "content": [
-    {"intro": "../README.md"},
+    {"intro": "introduction.md"},
     {"interop_factories": "interop_factories.md"}
   ],
+  "tocDepth": 1,
+  "numbering": false,
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"
 }

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,13 @@
+# Overview
+
+Memcached implementation of snapshot store
+
+## Installation
+
+```bash
+composer require prooph/memcached-snapshot-store
+```
+
+## Requirements
+
+- ext-memcached ^3.0

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+        >
+    <testsuite name="Prooph Memcached Snapshot Store Test Suite">
+        <directory>./tests/</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,4 +19,9 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <var name="memcached_host" value="localhost" />
+        <var name="memcached_port" value="11211" />
+    </php>
 </phpunit>

--- a/src/MemcachedSnapshotStore.php
+++ b/src/MemcachedSnapshotStore.php
@@ -71,7 +71,7 @@ final class MemcachedSnapshotStore implements SnapshotStore
                 $snapshot->aggregateType(),
                 $snapshot->lastVersion(),
                 $snapshot->createdAt()->format('Y-m-d\TH:i:s.u'),
-                $this->serializer->serialize($snapshot->aggregateRoot())
+                $this->serializer->serialize($snapshot->aggregateRoot()),
             ];
         }
 
@@ -82,7 +82,7 @@ final class MemcachedSnapshotStore implements SnapshotStore
     {
         $keys = $this->connection->getAllKeys();
 
-        foreach($keys as $item) {
+        foreach ($keys as $item) {
             if (substr($item, 0, strlen($aggregateType)) === $aggregateType) {
                 $this->connection->delete($item);
             }

--- a/tests/Container/MemcachedSnapshotStoreFactoryTest.php
+++ b/tests/Container/MemcachedSnapshotStoreFactoryTest.php
@@ -71,7 +71,9 @@ class MemcachedSnapshotStoreFactoryTest extends TestCase
 
         $container->get('my_connection')->willReturn($connection)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
-        $container->get('serializer_servicename')->willReturn(new CallbackSerializer(function() {}, function() {}))->shouldBeCalled();
+        $container->get('serializer_servicename')->willReturn(new CallbackSerializer(function () {
+        }, function () {
+        }))->shouldBeCalled();
 
         $factory = new MemcachedSnapshotStoreFactory();
         $snapshotStore = $factory($container->reveal());


### PR DESCRIPTION
According to https://github.com/prooph/proophessor/issues/38#issuecomment-336200542

- shorter headlines
- introduction instead of using entire README (better overview while browsing through the docs)